### PR TITLE
Prioritize GET routes on Stardust.current and Stardust.isCurrent

### DIFF
--- a/providers/StardustProvider.ts
+++ b/providers/StardustProvider.ts
@@ -3,6 +3,8 @@ import { RouterContract } from '@ioc:Adonis/Core/Route';
 import { ViewContract } from '@ioc:Adonis/Core/View';
 import StardustMiddleware from '../middleware/Stardust';
 
+type RoutesManifest = Record<string, { pattern: string; methods: string[] }>;
+
 /*
 |--------------------------------------------------------------------------
 | Stardust Provider
@@ -22,11 +24,17 @@ export default class StardustProvider {
      */
     const mainDomainRoutes = Route.toJSON()?.['root'] ?? [];
 
-    return mainDomainRoutes.reduce<Record<string, string>>((routes, route) => {
+    return mainDomainRoutes.reduce<RoutesManifest>((routes, route) => {
       if (route.name) {
-        routes[route.name] = route.pattern;
+        routes[route.name] = {
+          pattern: route.pattern,
+          methods: route.methods,
+        };
       } else if (typeof route.handler === 'string') {
-        routes[route.handler] = route.pattern;
+        routes[route.handler] = {
+          pattern: route.pattern,
+          methods: route.methods,
+        };
       }
 
       return routes;
@@ -53,7 +61,7 @@ export default class StardustProvider {
     });
   }
 
-  private registerRoutesGlobal(View: ViewContract, namedRoutes: Record<string, string>) {
+  private registerRoutesGlobal(View: ViewContract, namedRoutes: RoutesManifest) {
     View.global('routes', (cspNonce?: string) => {
       return `
 <script${cspNonce ? ` nonce="${cspNonce}"` : ''}>
@@ -68,7 +76,7 @@ export default class StardustProvider {
    * stardust's functionality on the server
    * @param namedRoutes
    */
-  private registerSsrRoutes(namedRoutes: Record<string, string>) {
+  private registerSsrRoutes(namedRoutes: RoutesManifest) {
     globalThis.stardust = { namedRoutes };
   }
 

--- a/src/client/UrlBuilder.ts
+++ b/src/client/UrlBuilder.ts
@@ -18,7 +18,7 @@ export class UrlBuilder {
    */
   private baseUrl: string;
 
-  constructor(private routes: Record<string, any>) {}
+  constructor(private routes: Record<string, { pattern: string; methods: string[] }>) {}
 
   /**
    * Processes the pattern with the route params
@@ -148,7 +148,7 @@ export class UrlBuilder {
    */
   public make(identifier: string) {
     const route = this.findRouteOrFail(identifier);
-    const url = this.processPattern(route);
+    const url = this.processPattern(route.pattern);
     return this.suffixQueryString(this.baseUrl ? `${this.baseUrl}${url}` : url);
   }
 }

--- a/test/Stardust.spec.ts
+++ b/test/Stardust.spec.ts
@@ -1,29 +1,90 @@
 import test from 'japa';
 import { Stardust } from '../src/client/Stardust';
+import { UrlBuilder } from '../src/client/UrlBuilder';
 
-test.group('Client', () => {
+const namedRoutes = {
+  'tasks.show': {
+    pattern: '/tasks/:id',
+    methods: ['GET'],
+  },
+  'tasks.update': {
+    pattern: '/tasks/:id',
+    methods: ['PUT'],
+  },
+};
+
+test.group('Client', (group) => {
+  group.afterEach(() => {
+    delete globalThis.stardust;
+    delete (globalThis as any).location;
+  });
+
+  test('should throw error if routes are not found', (assert) => {
+    assert.throws(() => {
+      // @ts-ignore
+      new Stardust();
+    }, 'Routes could not be found. Please make sure you use the `@routes()` tag in your view!');
+  });
+
   test('should return all routes', (assert) => {
-    const namedRoutes = { 'tasks.show': '/tasks/:id' };
     const stardust = new Stardust(namedRoutes);
 
     assert.equal(stardust.getRoutes(), namedRoutes);
   });
 
   test('should resolve route with object params', (assert) => {
-    const stardust = new Stardust({ 'tasks.show': '/tasks/:id' });
+    const stardust = new Stardust(namedRoutes);
 
     assert.equal(stardust.route('tasks.show', { id: 1 }), '/tasks/1');
   });
 
   test('should resolve route with array of params', (assert) => {
-    const stardust = new Stardust({ 'tasks.show': '/tasks/:id' });
+    const stardust = new Stardust(namedRoutes);
 
     assert.equal(stardust.route('tasks.show', [1]), '/tasks/1');
   });
 
   test('should resolve route with query string', (assert) => {
-    const stardust = new Stardust({ 'tasks.show': '/tasks' });
+    const stardust = new Stardust(namedRoutes);
 
-    assert.equal(stardust.route('tasks.show', undefined, { qs: { status: 'done' } }), '/tasks?status=done');
+    assert.equal(stardust.route('tasks.show', [1], { qs: { status: 'done' } }), '/tasks/1?status=done');
+  });
+
+  test('should resolve current route prioritizing GET routes', (assert) => {
+    const stardust = new Stardust(namedRoutes);
+
+    globalThis.stardust = { pathname: '/tasks/1' };
+
+    assert.equal(stardust.current, 'tasks.show');
+  });
+
+  test('isCurrent should return true if current route matches', (assert) => {
+    const stardust = new Stardust(namedRoutes);
+
+    globalThis.stardust = { pathname: '/tasks/1' };
+
+    assert.isTrue(stardust.isCurrent('tasks.show'));
+  });
+
+  test('isCurrent should return false if current route does not match', (assert) => {
+    const stardust = new Stardust(namedRoutes);
+
+    globalThis.stardust = { pathname: '/update' };
+
+    assert.isFalse(stardust.isCurrent('tasks.show'));
+  });
+
+  test('current should default to window/globalThis when stardust global isnt available', (assert) => {
+    const stardust = new Stardust(namedRoutes);
+
+    (globalThis as any).location = { href: '/update' };
+
+    assert.isFalse(stardust.isCurrent('tasks.show'));
+  });
+
+  test('should return a builder instance to build URL', (assert) => {
+    const stardust = new Stardust(namedRoutes);
+
+    assert.instanceOf(stardust.builder(), UrlBuilder);
   });
 });

--- a/test/StardustProvider.spec.ts
+++ b/test/StardustProvider.spec.ts
@@ -54,7 +54,7 @@ test.group('Server', (group) => {
     assert.equal(
       dummy.trim(),
       `<script>
-  (globalThis || window).stardust = {namedRoutes: {"index":"/","users.store":"/users"}};
+  (globalThis || window).stardust = {namedRoutes: {"index":{"pattern":"/","methods":["HEAD","GET"]},"users.store":{"pattern":"/users","methods":["POST"]}}};
 </script>`,
     );
   });


### PR DESCRIPTION
Fixes #10 

This prioritizes GET routes on Stardust.current and Stardust.isCurrent, returning the GET url if any other method matches the pattern.

This also is a breaking change for anyone who used the internals 